### PR TITLE
Add principalType to role assignments

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,9 +1,6 @@
 ARG VARIANT=bullseye
 FROM mcr.microsoft.com/vscode/devcontainers/base:0-${VARIANT}
-
-WORKDIR /extensions
 RUN curl -fsSL https://aka.ms/install-azd.sh | bash \
-    && curl -fsSLo azure-dev.vsix https://aka.ms/azure-dev/vsix \
     && curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.gpg \
     && mv microsoft.gpg /etc/apt/trusted.gpg.d/microsoft.gpg \
     && sh -c 'echo "deb [arch=amd64] https://packages.microsoft.com/debian/$(lsb_release -rs | cut -d'.' -f 1)/prod $(lsb_release -cs) main" > /etc/apt/sources.list.d/dotnetdev.list' \

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,19 +8,27 @@
     },
     "features": {
         "github-cli": "2",
-        "azure-cli": "2.36",
+        "azure-cli": "2.38",
+        "python": "os-provided",
         "dotnet": "6.0",
-        "docker-from-docker": "20.10"
+        "docker-from-docker": "20.10",
+        "node": {
+            "version": "16",
+            "nodeGypDependencies": false
+        }
     },
     "extensions": [
-        "/extensions/azure-dev.vsix",
-        "dbaeumer.vscode-eslint",
+        "ms-azuretools.azure-dev",
         "ms-azuretools.vscode-bicep",
         "ms-azuretools.vscode-docker",
         "ms-azuretools.vscode-azurefunctions",
+        "ms-vscode.vscode-node-azure-pack",
+        "ms-vscode.js-debug",
         "ms-dotnettools.csharp",
+        "ms-dotnettools.vscode-dotnet-runtime",
         "esbenp.prettier-vscode",
-        "ms-dotnettools.vscode-dotnet-runtime"
+        "eg2.vscode-npm-script",
+        "dbaeumer.vscode-eslint"
     ],
     "forwardPorts": [
         3000,

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,25 +9,17 @@
     "features": {
         "github-cli": "2",
         "azure-cli": "2.38",
-        "python": "os-provided",
         "dotnet": "6.0",
-        "docker-from-docker": "20.10",
-        "node": {
-            "version": "16",
-            "nodeGypDependencies": false
-        }
+        "docker-from-docker": "20.10"
     },
     "extensions": [
         "ms-azuretools.azure-dev",
         "ms-azuretools.vscode-bicep",
         "ms-azuretools.vscode-docker",
         "ms-azuretools.vscode-azurefunctions",
-        "ms-vscode.vscode-node-azure-pack",
-        "ms-vscode.js-debug",
         "ms-dotnettools.csharp",
         "ms-dotnettools.vscode-dotnet-runtime",
         "esbenp.prettier-vscode",
-        "eg2.vscode-npm-script",
         "dbaeumer.vscode-eslint"
     ],
     "forwardPorts": [

--- a/infra/servicebus-FunctionApp-Rbac.bicep
+++ b/infra/servicebus-FunctionApp-Rbac.bicep
@@ -13,6 +13,7 @@ resource rbacReceiveMessage 'Microsoft.Authorization/roleAssignments@2020-10-01-
   properties: {
     principalId: PrincipalId
     roleDefinitionId: serviceBusDataReceiver
+    principalType: 'ServicePrincipal'
   }
 }
 
@@ -23,5 +24,6 @@ resource rbacSendMessage 'Microsoft.Authorization/roleAssignments@2020-10-01-pre
   properties: {
     principalId: PrincipalId
     roleDefinitionId: serviceBusDataSender
+    principalType: 'ServicePrincipal'
   }
 }


### PR DESCRIPTION
When assigning roles to SP you need to tell ARM that it is an SP so it won't error when it doesn't find the SP.  SPs take time to replicate throughout the system.